### PR TITLE
UO Rebranding — Phases 2+ (brand restyle, blog, content)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,16 @@
-theme: jekyll-theme-cayman
+# University of Oregon Cybersecurity Club — site + blog config
+title: University of Oregon Cybersecurity Club
+description: News, meeting recaps, and event updates from the UO Cybersecurity Club.
+url: "https://uosec.org"
+
+# Blog posts live under /blog/YYYY/MM/DD/title/
+permalink: /blog/:year/:month/:day/:title/
+
+# Show newest posts first on the blog index
+paginate: 10
+
+# Custom layouts in _layouts/ provide the club's look — no external theme.
+# The hand-written static pages (index.html, ctf.html, etc.) have no front
+# matter, so Jekyll copies them through untouched.
+exclude:
+  - README.md

--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,9 @@ permalink: /blog/:year/:month/:day/:title/
 
 # Show newest posts first on the blog index
 paginate: 10
+paginate_path: /blog/page:num/
+plugins:
+  - jekyll-paginate
 
 # Custom layouts in _layouts/ provide the club's look — no external theme.
 # The hand-written static pages (index.html, ctf.html, etc.) have no front

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,9 +7,9 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta name="description" content="{{ page.description | default: site.description }}">
 	<title>{% if page.title %}{{ page.title }} | {% endif %}University of Oregon Cybersecurity Club</title>
-	<link rel="shortcut icon" href="/media/images/uoseclogo.svg" />
-	<link href="/styles/styles.css" rel="stylesheet">
-	<script src="/scripts/bg.js"></script>
+	<link rel="shortcut icon" href="{{ '/media/images/uoseclogo.svg' | relative_url }}" />
+	<link href="{{ '/styles/styles.css' | relative_url }}" rel="stylesheet">
+	<script src="{{ '/scripts/bg.js' | relative_url }}"></script>
 </head>
 
 <body>
@@ -17,24 +17,24 @@
 	<div class="nav-bar">
 		<nav>
 			<ul class="navbar">
-				<img class="corner-logo" src="/media/images/uoseclogo.svg">
+				<img class="corner-logo" src="{{ '/media/images/uoseclogo.svg' | relative_url }}">
 				<li class="nav-item">
-					<a class="nav-link" href="/index.html">Home</a>
+					<a class="nav-link" href="{{ '/index.html' | relative_url }}">Home</a>
 				</li>
 				<li class="nav-item">
-					<a class="nav-link" href="/ctf.html">CTF</a>
+					<a class="nav-link" href="{{ '/ctf.html' | relative_url }}">CTF</a>
 				</li>
 				<li class="nav-item">
-					<a class="nav-link" href="/links.html">Resources</a>
+					<a class="nav-link" href="{{ '/links.html' | relative_url }}">Resources</a>
 				</li>
 				<li class="nav-item">
-					<a class="nav-link" href="/team.html">Staff</a>
+					<a class="nav-link" href="{{ '/team.html' | relative_url }}">Staff</a>
 				</li>
 				<li class="nav-item">
-					<a class="nav-link" href="/calendar.html">Calendar</a>
+					<a class="nav-link" href="{{ '/calendar.html' | relative_url }}">Calendar</a>
 				</li>
 				<li class="nav-item">
-					<a class="nav-link" href="/blog.html">Blog</a>
+					<a class="nav-link" href="{{ '/blog/' | relative_url }}">Blog</a>
 				</li>
 			</ul>
 		</nav>
@@ -52,13 +52,13 @@
 	<footer>
 		<div class="social-icons">
 			<a href="https://www.instagram.com/uo_sec/">
-				<img class="icon-1" src="/media/images/ig-icon.svg">
+				<img class="icon-1" src="{{ '/media/images/ig-icon.svg' | relative_url }}">
 			</a>
 			<a href="https://discord.com/invite/wn4T3byxh4">
-				<img class="icon-2" src="/media/images/discord-icon.svg">
+				<img class="icon-2" src="{{ '/media/images/discord-icon.svg' | relative_url }}">
 			</a>
 			<a href="mailto:uosecurityclub@uoregon.edu">
-				<img class="icon-3" src="/media/images/mail-icon.svg">
+				<img class="icon-3" src="{{ '/media/images/mail-icon.svg' | relative_url }}">
 			</a>
 		</div>
 		<p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta name="description" content="{{ page.description | default: site.description }}">
+	<title>{% if page.title %}{{ page.title }} | {% endif %}University of Oregon Cybersecurity Club</title>
+	<link rel="shortcut icon" href="/media/images/uoseclogo.svg" />
+	<link href="/styles/styles.css" rel="stylesheet">
+	<script src="/scripts/bg.js"></script>
+</head>
+
+<body>
+	<!-- Head -->
+	<div class="nav-bar">
+		<nav>
+			<ul class="navbar">
+				<img class="corner-logo" src="/media/images/uoseclogo.svg">
+				<li class="nav-item">
+					<a class="nav-link" href="/index.html">Home</a>
+				</li>
+				<li class="nav-item">
+					<a class="nav-link" href="/ctf.html">CTF</a>
+				</li>
+				<li class="nav-item">
+					<a class="nav-link" href="/links.html">Resources</a>
+				</li>
+				<li class="nav-item">
+					<a class="nav-link" href="/team.html">Staff</a>
+				</li>
+				<li class="nav-item">
+					<a class="nav-link" href="/calendar.html">Calendar</a>
+				</li>
+				<li class="nav-item">
+					<a class="nav-link" href="/blog.html">Blog</a>
+				</li>
+			</ul>
+		</nav>
+	</div>
+	<!--End head------------------------------------------------------------------>
+
+	<article>
+		<canvas id="parallaxCanvas"></canvas>
+		<div class="content">
+			{{ content }}
+		</div>
+	</article>
+
+	<!--- Footer (used for all pages on the website) -->
+	<footer>
+		<div class="social-icons">
+			<a href="https://www.instagram.com/uo_sec/">
+				<img class="icon-1" src="/media/images/ig-icon.svg">
+			</a>
+			<a href="https://discord.com/invite/wn4T3byxh4">
+				<img class="icon-2" src="/media/images/discord-icon.svg">
+			</a>
+			<a href="mailto:uosecurityclub@uoregon.edu">
+				<img class="icon-3" src="/media/images/mail-icon.svg">
+			</a>
+		</div>
+		<p>
+			&copy; UOSEC 2026
+		</p>
+	</footer>
+</body>
+
+</html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -9,5 +9,5 @@ layout: default
 		{{ content }}
 	</div>
 
-	<p class="post-back"><a href="/blog.html">&larr; Back to all posts</a></p>
+	<p class="post-back"><a href="{{ '/blog/' | relative_url }}">&larr; Back to all posts</a></p>
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,13 @@
+---
+layout: default
+---
+<div class="post">
+	<div class="title">{{ page.title }}</div>
+	<p class="post-meta">{{ page.date | date: "%B %-d, %Y" }}{% if page.author %} &middot; {{ page.author }}{% endif %}</p>
+
+	<div class="post-content">
+		{{ content }}
+	</div>
+
+	<p class="post-back"><a href="/blog.html">&larr; Back to all posts</a></p>
+</div>

--- a/_posts/2026-07-08-welcome-to-the-uosec-blog.md
+++ b/_posts/2026-07-08-welcome-to-the-uosec-blog.md
@@ -1,0 +1,40 @@
+---
+layout: post
+title: "Welcome to the UOSec Blog"
+date: 2026-07-08
+author: UO Cybersecurity Club
+description: Kicking off the club blog — what to expect and how officers can post updates.
+---
+
+Welcome to the official blog of the University of Oregon Cybersecurity Club. This is where we'll post meeting recaps, CTF write-ups, event announcements, and updates for members and the wider UO community.
+
+## What you'll find here
+
+- **Meeting recaps** — what we covered, links to slides, and what's coming up next
+- **Event write-ups** — CTF competitions, summits, and workshops
+- **Announcements** — deadlines, guest speakers, and opportunities to get involved
+
+## For officers: how to post
+
+Adding a post takes about two minutes and needs no local setup — just a browser:
+
+1. On GitHub, open the **`_posts`** folder in this repository.
+2. Click **Add file → Create new file**.
+3. Name the file using the pattern `YYYY-MM-DD-your-title.md` — for example, `2026-10-02-week-1-recap.md`.
+4. Start the file with this header block, then write your post in Markdown below it:
+
+   ```
+   ---
+   layout: post
+   title: "Your Post Title"
+   date: 2026-10-02
+   author: Your Name
+   description: One-line summary shown on the blog index.
+   ---
+
+   Write your post here using Markdown.
+   ```
+
+5. Commit the file (or open a pull request). Once it's merged to `master`, the post appears on the Blog page automatically — the site rebuilds itself.
+
+That's it. No HTML, no build tools — just Markdown.

--- a/bird.html
+++ b/bird.html
@@ -49,7 +49,7 @@
     .background {
         height: 100vh;
         width: 100vw;
-        background-color: #363B49;
+        background-color: #154733;
     }
 
     .bird {
@@ -67,7 +67,7 @@
         left: 100vw;
         height: 70vh;
         width: 6vw;
-        background-color: #FFDE1D;
+        background-color: #FEE123;
         box-shadow: 20px -20px 15px rgba(13, 15, 22, 0.25);
     }
 

--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,21 @@
+---
+layout: default
+title: Blog
+description: Meeting recaps, event write-ups, and announcements from the UO Cybersecurity Club.
+---
+<div class="title">CLUB BLOG</div>
+<p style="text-align:center;">Meeting recaps, event write-ups, and announcements from the UO Cybersecurity Club.</p>
+
+<div class="post-list">
+	{% for post in site.posts %}
+	<a class="post-card" href="{{ post.url }}">
+		<span class="post-card-date">{{ post.date | date: "%b %-d, %Y" }}</span>
+		<span class="post-card-title">{{ post.title }}</span>
+		{% if post.description %}<span class="post-card-excerpt">{{ post.description }}</span>{% endif %}
+	</a>
+	{% endfor %}
+
+	{% if site.posts.size == 0 %}
+	<p style="text-align:center; margin-top:30px;">No posts yet &mdash; check back soon!</p>
+	{% endif %}
+</div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -7,15 +7,27 @@ description: Meeting recaps, event write-ups, and announcements from the UO Cybe
 <p style="text-align:center;">Meeting recaps, event write-ups, and announcements from the UO Cybersecurity Club.</p>
 
 <div class="post-list">
-	{% for post in site.posts %}
-	<a class="post-card" href="{{ post.url }}">
+	{% for post in paginator.posts %}
+	<a class="post-card" href="{{ post.url | relative_url }}">
 		<span class="post-card-date">{{ post.date | date: "%b %-d, %Y" }}</span>
 		<span class="post-card-title">{{ post.title }}</span>
 		{% if post.description %}<span class="post-card-excerpt">{{ post.description }}</span>{% endif %}
 	</a>
 	{% endfor %}
 
-	{% if site.posts.size == 0 %}
+	{% if paginator.posts.size == 0 %}
 	<p style="text-align:center; margin-top:30px;">No posts yet &mdash; check back soon!</p>
 	{% endif %}
 </div>
+
+{% if paginator.total_pages > 1 %}
+<p class="post-back">
+	{% if paginator.previous_page %}
+	<a href="{{ paginator.previous_page_path | relative_url }}">&larr; Newer posts</a>
+	{% endif %}
+	{% if paginator.previous_page and paginator.next_page %}&nbsp;&middot;&nbsp;{% endif %}
+	{% if paginator.next_page %}
+	<a href="{{ paginator.next_page_path | relative_url }}">Older posts &rarr;</a>
+	{% endif %}
+</p>
+{% endif %}

--- a/calendar.html
+++ b/calendar.html
@@ -54,7 +54,7 @@
 			<br>
 			<iframe class="calendar"
 				src="https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23ffffff&ctz=America%2FLos_Angeles&title=UOSec%20Calendar&showNav=1&showPrint=0&showCalendars=0&src=dW9jeWJlcmluZm9AZ21haWwuY29t&src=MHFpMTVwcWNlMHBibzNyamhlcHU2ZXJicHJlbDhxM3BAaW1wb3J0LmNhbGVuZGFyLmdvb2dsZS5jb20&color=%23039BE5&color=%234285F4"
-				style="border:solid 5px #9FA1A3" frameborder="0" scrolling="no">
+				style="border:solid 5px #154733" frameborder="0" scrolling="no">
 			</iframe>
 		</div>
 	</article>

--- a/calendar.html
+++ b/calendar.html
@@ -5,7 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta name="description" content="The official website of the University of Oregon Cybersecurity Club">
+	<meta name="description" content="Upcoming meetings, CTF competitions, summits, and events for the University of Oregon Cybersecurity Club.">
 	<meta name="keywords" content="University, of, Oregon, Cybersecurity, Club, UO, cyber, security, clubs, ctf">
 	<meta name="google-site-verification" content="Ykx8mQAHi4WhIP6vn9zxa6az8s_-HGDF5lAEs9fTf4Y" />
 	<title>Calendar | University of Oregon Cybersecurity Club</title>

--- a/calendar.html
+++ b/calendar.html
@@ -36,7 +36,7 @@
 					<a class="nav-link" href="calendar.html">Calendar</a>
 				</li>
 				<li class="nav-item">
-					<a class="nav-link" href="blog.html">Blog</a>
+					<a class="nav-link" href="blog/">Blog</a>
 				</li>
 			</ul>
 		</nav>

--- a/calendar.html
+++ b/calendar.html
@@ -35,6 +35,9 @@
 				<li class="nav-item">
 					<a class="nav-link" href="calendar.html">Calendar</a>
 				</li>
+				<li class="nav-item">
+					<a class="nav-link" href="blog.html">Blog</a>
+				</li>
 			</ul>
 		</nav>
 	</div>

--- a/ctf.html
+++ b/ctf.html
@@ -35,6 +35,9 @@
                 <li class="nav-item">
                     <a class="nav-link" href="calendar.html">Calendar</a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="blog.html">Blog</a>
+                </li>
             </ul>
         </nav>
     </div>

--- a/ctf.html
+++ b/ctf.html
@@ -5,7 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta name="description" content="The official website of the University of Oregon Cybersecurity Club">
+	<meta name="description" content="Capture the Flag (CTF) competitions explained — the challenge categories the University of Oregon Cybersecurity Club trains for.">
 	<meta name="keywords" content="University, of, Oregon, Cybersecurity, Club, UO, cyber, security, clubs, ctf">
 	<meta name="google-site-verification" content="Ykx8mQAHi4WhIP6vn9zxa6az8s_-HGDF5lAEs9fTf4Y" />
 	<title>Capture the Flag | University of Oregon Cybersecurity Club</title>

--- a/ctf.html
+++ b/ctf.html
@@ -36,7 +36,7 @@
                     <a class="nav-link" href="calendar.html">Calendar</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="blog.html">Blog</a>
+                    <a class="nav-link" href="blog/">Blog</a>
                 </li>
             </ul>
         </nav>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta name="description" content="The official website of the University of Oregon Cybersecurity Club">
+	<meta name="description" content="The University of Oregon Cybersecurity Club — student-run cybersecurity training, CTF competitions, workshops, and events at UO.">
 	<meta name="keywords" content="University, of, Oregon, Cybersecurity, Club, UO, cyber, security, clubs, ctf">
 	<meta name="google-site-verification" content="Ykx8mQAHi4WhIP6vn9zxa6az8s_-HGDF5lAEs9fTf4Y" />
 	<title>Home | University of Oregon Cybersecurity Club</title>
@@ -95,7 +95,7 @@
 
 					<div class="discord-header">
 						<span class="discord-label">INVITE</span>
-						<span class="discord-header-text">John Doe invited you to join</span>
+						<span class="discord-header-text">You've been invited to join</span>
 					</div>
 
 					<div class="discord-body">
@@ -107,7 +107,7 @@
 
 							<div class="discord-stats">
 								<span class="online-dot"></span>
-								67 members online
+								Join our community
 							</div>
 						</div>
 					</div>

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
 					<a class="nav-link" href="calendar.html">Calendar</a>
 				</li>
 				<li class="nav-item">
-					<a class="nav-link" href="blog.html">Blog</a>
+					<a class="nav-link" href="blog/">Blog</a>
 				</li>
 			</ul>
 		</nav>

--- a/index.html
+++ b/index.html
@@ -35,6 +35,9 @@
 				<li class="nav-item">
 					<a class="nav-link" href="calendar.html">Calendar</a>
 				</li>
+				<li class="nav-item">
+					<a class="nav-link" href="blog.html">Blog</a>
+				</li>
 			</ul>
 		</nav>
 	</div>

--- a/links.html
+++ b/links.html
@@ -8,7 +8,7 @@
 	<meta name="description" content="Cybersecurity resources, CTF training, partner organizations, and career opportunities curated by the University of Oregon Cybersecurity Club.">
 	<meta name="keywords" content="University, of, Oregon, Cybersecurity, Club, UO, cyber, security, clubs, ctf">
 	<meta name="google-site-verification" content="Ykx8mQAHi4WhIP6vn9zxa6az8s_-HGDF5lAEs9fTf4Y" />
-	<title>Capture the Flag | University of Oregon Cybersecurity Club</title>
+	<title>Resources | University of Oregon Cybersecurity Club</title>
 	<link rel="shortcut icon" href="media/images/uoseclogo.svg" />
 	<link href="styles/styles.css" rel="stylesheet">
 	<script src="scripts/bg.js"></script>

--- a/links.html
+++ b/links.html
@@ -5,7 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta name="description" content="The official website of the University of Oregon Cybersecurity Club">
+	<meta name="description" content="Cybersecurity resources, CTF training, partner organizations, and career opportunities curated by the University of Oregon Cybersecurity Club.">
 	<meta name="keywords" content="University, of, Oregon, Cybersecurity, Club, UO, cyber, security, clubs, ctf">
 	<meta name="google-site-verification" content="Ykx8mQAHi4WhIP6vn9zxa6az8s_-HGDF5lAEs9fTf4Y" />
 	<title>Capture the Flag | University of Oregon Cybersecurity Club</title>

--- a/links.html
+++ b/links.html
@@ -158,7 +158,7 @@
 							<a href="https://cybersecurityguide.org/">Cybersecurity Guide</a>
 						</li>
 						<li>
-							<a style="color:#8aa8c4;" target="_blank" onmouseover="this.style.color='#FFFFFF'" onmouseleave="this.style.color='#8aa8c4'" href="https://jdsmithartwork.com">jdsmithartwork.com</a>
+							<a style="color:#2E6B4F;" target="_blank" onmouseover="this.style.color='#FFFFFF'" onmouseleave="this.style.color='#2E6B4F'" href="https://jdsmithartwork.com">jdsmithartwork.com</a>
 						</li>
 					</ul>
 				</div>

--- a/links.html
+++ b/links.html
@@ -36,7 +36,7 @@
 					<a class="nav-link" href="calendar.html">Calendar</a>
 				</li>
 				<li class="nav-item">
-					<a class="nav-link" href="blog.html">Blog</a>
+					<a class="nav-link" href="blog/">Blog</a>
 				</li>
 			</ul>
 		</nav>

--- a/links.html
+++ b/links.html
@@ -35,6 +35,9 @@
 				<li class="nav-item">
 					<a class="nav-link" href="calendar.html">Calendar</a>
 				</li>
+				<li class="nav-item">
+					<a class="nav-link" href="blog.html">Blog</a>
+				</li>
 			</ul>
 		</nav>
 	</div>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -87,7 +87,7 @@
 }
 
 body {
-  background: #363B49;
+  background: #154733;
   -webkit-background-size: cover;
   -moz-background-size: cover;
   background-size: cover;
@@ -133,7 +133,7 @@ article {
 .nav-bar {
   width: 100%;
   position: fixed;
-  background-color: #363B49;
+  background-color: #154733;
   top: 0;
   left: 0;
   z-index: 1;
@@ -177,7 +177,7 @@ nav ul a {
 }
 
 nav a:hover {
-  color: rgb(255, 217, 0);
+  color: #FEE123;
 }
 
 @media(max-width: 600px) {
@@ -221,7 +221,7 @@ nav a:hover {
 
 .banner {
   border: solid 5px #B5B4B4;
-  border-bottom: solid 10px #B5B4B4;
+  border-bottom: solid 10px #154733;
   padding: 25px 15px 25px 15px;
   text-align: center;
 }
@@ -278,6 +278,7 @@ h2 {
   font-family: Red Hat Mono;
   font-weight: 600;
   font-size: 20pt;
+  color: #154733;
 }
 
 p {
@@ -439,7 +440,8 @@ iframe {
   text-align: center;
   font-size: 20px;
   user-select: none;
-  background-color: white;
+  color: #ffffff;
+  background-color: #154733;
   border-radius: 40px;
   box-shadow: 0px 8px 5px rgba(0, 0, 0, 0.25);
   transition: transform 0.25s ease, background-color 0.25s ease;
@@ -459,21 +461,21 @@ iframe {
     height: 90px;
     right: 40px;
     border-radius: 50px;
-    border: solid 2px #535a6e;
+    border: solid 2px #FEE123;
   }
 }
 
 
 .join-us:hover {
   transform: translateY(-3px);
-  background-color: #e9e9e9;
+  background-color: #0e3624;
   cursor: pointer;
   font-weight: 900;
 }
 
 .join-us a {
   text-decoration: none;
-  color: #222;
+  color: #ffffff;
 }
 
 footer {
@@ -482,7 +484,7 @@ footer {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  background-color: #363B49;
+  background-color: #154733;
   color: white;
   padding: 15px 0px 15px 0px;
   margin: 0;
@@ -513,6 +515,7 @@ footer .icon-3 {
   font-size: 50px;
   justify-self: center;
   text-align: center;
+  color: #154733;
 }
 
 .dropdown-parent {
@@ -535,6 +538,7 @@ details h2 {
   font-family: United Sans;
   font-weight: 800;
   margin: 5px auto;
+  color: #1a1a1a;
 }
 
 summary {
@@ -551,27 +555,27 @@ summary {
 }
 
 .dropdown-1 {
-  background-color: #8A98B7;
+  background-color: #A8C5B4;
 }
 
 .dropdown-1[open] {
-  background-color: #8A98B7;
+  background-color: #A8C5B4;
 }
 
 .dropdown-2 {
-  background-color: #8A8CB5;
+  background-color: #95BAA6;
 }
 
 .dropdown-3 {
-  background-color: #AF8AB5;
+  background-color: #82B098;
 }
 
 .dropdown-4 {
-  background-color: #B58AA0;
+  background-color: #6FA68A;
 }
 
 .dropdown-5 {
-  background-color: #B58A8A;
+  background-color: #5C9B7C;
 }
 
 .dropdown-content {
@@ -629,7 +633,7 @@ summary {
 }
 
 .resources-parent a {
-  color: #222;
+  color: #154733;
   transition: color 0.15s ease, font-weight 0.15s ease;
 }
 
@@ -640,13 +644,13 @@ summary {
 .resources-1,
 .resources-2,
 .resources-3 {
-  background-color: #AEBDCE;
+  background-color: #B9CFC2;
 }
 
 .resources-4,
 .resources-5,
 .resources-6 {
-  background-color: #85A3C1;
+  background-color: #8FB3A0;
 }
 
 @media(max-width: 600px) {
@@ -799,7 +803,7 @@ summary {
   height: 50px;
   margin: 0;
   padding: 0;
-  color: #363B49;
+  color: #154733;
   font-family: Open Sans;
   font-size: 30px;
   border-radius: 50px;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -862,3 +862,108 @@ summary {
     width: 250px;
   }
 }
+
+/* Blog styling ------------------------------------------------------*/
+
+.post-meta {
+  text-align: center;
+  font-family: Red Hat Mono, monospace;
+  color: #154733;
+  margin: 5px 0 25px 0;
+}
+
+.post-content {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.post-content h2,
+.post-content h3 {
+  font-family: United Sans;
+  color: #154733;
+}
+
+.post-content p,
+.post-content li {
+  font-size: 13pt;
+  line-height: 1.6;
+}
+
+.post-content ul,
+.post-content ol {
+  margin: 0 30px;
+  padding-left: 20px;
+}
+
+.post-content pre {
+  background-color: #f4f6f5;
+  border-left: 4px solid #154733;
+  padding: 15px;
+  overflow-x: auto;
+  border-radius: 4px;
+}
+
+.post-content code {
+  font-family: Red Hat Mono, monospace;
+  font-size: 11pt;
+}
+
+.post-content a {
+  color: #154733;
+  font-weight: 600;
+}
+
+.post-back {
+  text-align: center;
+  margin-top: 40px;
+}
+
+.post-back a {
+  color: #154733;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.post-list {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  max-width: 780px;
+  margin: 30px auto 0 auto;
+}
+
+.post-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 20px 25px;
+  border: solid 2px #D1D3D4;
+  border-left: solid 8px #154733;
+  border-radius: 0px 12px 12px 0px;
+  text-decoration: none;
+  color: #222;
+  transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.post-card:hover {
+  border-left-color: #FEE123;
+  transform: translateX(3px);
+  box-shadow: 0px 6px 14px rgba(30, 30, 30, 0.12);
+}
+
+.post-card-date {
+  font-family: Red Hat Mono, monospace;
+  font-size: 11pt;
+  color: #154733;
+}
+
+.post-card-title {
+  font-family: United Sans;
+  font-weight: 800;
+  font-size: 17pt;
+}
+
+.post-card-excerpt {
+  font-size: 12pt;
+  color: #444;
+}

--- a/team.html
+++ b/team.html
@@ -5,7 +5,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="The official website of the University of Oregon Cybersecurity Club">
+    <meta name="description" content="Meet the student leadership of the University of Oregon Cybersecurity Club.">
     <meta name="keywords" content="University, of, Oregon, Cybersecurity, Club, UO, cyber, security, clubs, ctf">
     <meta name="google-site-verification" content="Ykx8mQAHi4WhIP6vn9zxa6az8s_-HGDF5lAEs9fTf4Y" />
     <title>Meet The Team | University of Oregon Cybersecurity Club</title>

--- a/team.html
+++ b/team.html
@@ -35,6 +35,9 @@
                 <li class="nav-item">
                     <a class="nav-link" href="calendar.html">Calendar</a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="blog.html">Blog</a>
+                </li>
             </ul>
         </nav>
     </div>

--- a/team.html
+++ b/team.html
@@ -36,7 +36,7 @@
                     <a class="nav-link" href="calendar.html">Calendar</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="blog.html">Blog</a>
+                    <a class="nav-link" href="blog/">Blog</a>
                 </li>
             </ul>
         </nav>


### PR DESCRIPTION
Rolling PR for the UO Cyber Club site rebrand, on the `UO-Rebranding-Branch`. Supersedes #14 (auto-closed when the source branch was renamed).

**Phase 2 — UO brand restyle (done):** colors-only, in place. Nav/footer/background → UO green #154733; approximate yellows → official UO yellow #FEE123; terminal headings, CTF title, banner underline, Join Us button → green; CTF dropdowns + Resources tiles re-tinted to a UO green scale; calendar/links/bird inline colors harmonized. Preserved all content, UO United fonts, calendar embed, widgets, club logo (official UO 'O' logo intentionally NOT added — trademark ask pending).

Further phases (Jekyll markdown blog, content pass) will be pushed to this same branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public static-site and styling changes only; no auth or backend. Confirm GitHub Pages builds with `jekyll-paginate` before merge.
> 
> **Overview**
> **UO brand restyle** shifts the site palette from gray-blue to UO green (`#154733`) and official yellow (`#FEE123`) across `styles/styles.css` (nav, footer, body, headings, Join Us, CTF dropdowns, Resources tiles) and the `bird.html` easter-egg game.
> 
> **Jekyll blog** is wired up via expanded `_config.yml` (site metadata, `/blog/:year/:month/:day/:title/` permalinks, `jekyll-paginate`). New `_layouts/default.html` and `post.html` share nav/footer with a **Blog** link; `blog/index.html` lists paginated posts; a welcome post in `_posts/` documents officer posting workflow.
> 
> **Static pages** gain the Blog nav item, tighter per-page `<meta name="description">` copy, a corrected Resources page title on `links.html`, greener calendar embed border, and small home-page Discord invite text tweaks (generic invite line, “Join our community” instead of a hard-coded member count).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65335f84a1e9ed310b9f2d31c4779967766538bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->